### PR TITLE
Fix max attribute in form.rst

### DIFF
--- a/source/how-tos/app-development/interactive/form.rst
+++ b/source/how-tos/app-development/interactive/form.rst
@@ -377,14 +377,14 @@ are:
 
        .. code-block:: yaml
 
-          min: null
+          max: null
 
      Example
        Set maximum value of 15
 
        .. code-block:: yaml
 
-          min: 15
+          max: 15
 
 .. describe:: step (Integer, null)
 


### PR DESCRIPTION
https://osc.github.io/ood-documentation/latest/app-development/interactive/form.html

In the max attribute section the code examples use min, but should be max.